### PR TITLE
fix: Fix URL issue.

### DIFF
--- a/src/idoc.ts
+++ b/src/idoc.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import path from 'path';
+import { fileURLToPath } from 'url';
 import minimist from 'minimist';
 import fs from 'fs-extra';
 import { build } from './scripts/build.js';
@@ -52,7 +53,7 @@ if (argvs.h || argvs.help) {
 (async () => {
   try {
     if (argvs.v || argvs.version) {
-      const pkgpath = path.resolve(new URL('../package.json', import.meta.url).pathname);
+      const pkgpath = fileURLToPath(new URL('../package.json', import.meta.url));
       const { version } = await fs.readJSON(pkgpath);
       console.log(` \x1b[35midoc\x1b[0m v${version}\n`);
       process.exit(0);

--- a/src/scripts/init.ts
+++ b/src/scripts/init.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { fileURLToPath } from 'url';
 import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import { copyFile } from '../utils/copy.js';
@@ -53,12 +54,12 @@ export async function init(folder: string) {
   }
 
   if (option.theme) {
-    const themepath = path.resolve(new URL('../../themes', import.meta.url).pathname);
+    const themepath = fileURLToPath(new URL('../../themes', import.meta.url));
     await fs.copy(themepath, path.resolve(initFolder, 'themes'));
   }
 
-  const temp = path.resolve(new URL('../../template', import.meta.url).pathname);
-  const pkgpath = path.resolve(new URL('../../package.json', import.meta.url).pathname);
+  const temp = fileURLToPath(new URL('../../template', import.meta.url));
+  const pkgpath = fileURLToPath(new URL('../../package.json', import.meta.url));
   const pkg = await fs.readJSON(pkgpath);
 
   await copyFile(path.resolve(temp, 'idoc.yml'), path.resolve(initFolder, 'idoc.yml'), {

--- a/src/utils/conf.ts
+++ b/src/utils/conf.ts
@@ -1,6 +1,7 @@
 import { parse } from 'yaml';
 import fs from 'fs-extra';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import image2uri from 'image2uri';
 import readdirFiles, { getExt, IFileDirStat } from 'recursive-readdir-files';
 import { logo } from './logo.js';
@@ -162,10 +163,10 @@ export class Conf {
     }
 
     if (this.data.theme === 'default' || !this.data.theme) {
-      this.data.theme = path.resolve(new URL('../../themes/default', import.meta.url).pathname);
+      this.data.theme = fileURLToPath(fileURLToPath(new URL('../../themes/default', import.meta.url)));
     }
 
-    const pkgIdoc = await fs.readJSON(new URL('../../package.json', import.meta.url).pathname);
+    const pkgIdoc = await fs.readJSON(fileURLToPath(new URL('../../package.json', import.meta.url)));
     this.data.idocVersion = pkgIdoc.version;
     if (this.data.footer) {
       this.footer = this.data.footer;


### PR DESCRIPTION
在window11下执行任意命令
会报错
```js
D:\D:\aforever\idoc\package.json
 idoc: [Error: ENOENT: no such file or directory, open 'D:\D:\aforever\idoc\package.json'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'D:\\D:\\aforever\\idoc\\package.json'
}
```

原因是因为路径不对,示例如下，`d:\d:\`导致路径错误找不到文件
```js
import path from 'path';
import {fileURLToPath} from 'url';
console.log(path.resolve(new URL('./package.json', import.meta.url).pathname));
// d:\d:\aprepare\idoctest\package.json
console.log(fileURLToPath(new URL('./package.json', import.meta.url)));
// d:\aprepare\idoctest\package.json
```

 建议使用 [fileURLToPath](http://nodejs.cn/api/url/url_fileurltopath_url.html)可以把文件网址字符串或网址对象转换为完全解析的特定于平台的 Node.js 文件路径