### PR TITLE
Fixed media query for mobile

### DIFF
--- a/themes/default/css/media.css
+++ b/themes/default/css/media.css
@@ -6,13 +6,8 @@
 }
 
 @media screen and (max-width: 900px) {
-  .warpper-content {
-    grid-template-columns: minmax(0, 3.5fr);
-    grid-template-areas: 'main';
-  }
-  .warpper-content.sidebar {
-    grid-template-areas: 'sidebar main';
-    grid-template-columns: 180px minmax(0, 41rem);
+  .warpper-content{
+    display: block !important;
   }
   nav.tocs {
     display: none;


### PR DESCRIPTION
This code change makes it so that there is no grid when viewed on a mobile (anything with max width 900px) as the navbar is already removed and there is no need for this extra whitespace.

Before:
![image](https://user-images.githubusercontent.com/60571306/226219609-5459c73c-9e97-4998-a111-a54d3aa85c27.png)
After:
![image](https://user-images.githubusercontent.com/60571306/226219627-e77d69fd-c928-4358-a60f-a715129e1cd2.png)

Notice how there is a gap in the first one on the right, this is due to the grid, setting this to a display of block will get rid of this and in the same media query the navbar is disregarded (`display:none`) so there is no need for that empty space or to display it elsewhere